### PR TITLE
Add support for both children and code prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,20 @@ import { h } from 'preact';
 import html from 'preact-html';
 import Prism from 'prismjs';
 
-const Code = ({ code, language, className, ...rest }) => (
-  <pre
-    {...rest}
-    class={[`language-${language}`, rest.class, className]
-      .filter(Boolean)
-      .join(' ')}
-  >
-    <code class={`language-${language}`}>
-      {html(Prism.highlight(code, Prism.languages[language]))}
-    </code>
-  </pre>
-);
+const Code = ({ language, className, ...rest }) => {
+    const code = rest.children && rest.children.length > 0 ? rest.children[0] : (rest.code || "");
+    return (
+        <pre
+            {...rest}
+            class={[`language-${language}`, rest.class, className]
+                .filter(Boolean)
+                .join(' ')}
+        >
+            <code class={`language-${language}`}>
+                {html(Prism.highlight(code, Prism.languages[language]))}
+            </code>
+        </pre>
+    )
+};
 
 export default Code;


### PR DESCRIPTION
This PR allows both kinds of usage: 

```html
<Code language="markup">
 {`<input type="hidden" name="_subject" value="New submission"  />
<input type="hidden" name="_cc" value="incoming@company.com"  />
<input type="hidden" name="_template" value="https://mycompany.com/emails/contact_us.html"  />
<input type="hidden" name="_templateType" value="handlebars"  />
<input type="text" name="_replyTo"   />`}
</Code>
```
and
```html
<Code language="markup" code={`<input type="hidden" name="_subject" value="New submission"  />
<input type="hidden" name="_cc" value="incoming@company.com"  />
<input type="hidden" name="_template" value="https://mycompany.com/emails/contact_us.html"  />
<input type="hidden" name="_templateType" value="handlebars"  />
<input type="text" name="_replyTo"   />`}  />
```
